### PR TITLE
Support Markdown to Word conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # md-to-confluence
 
-A simple utility to convert Markdown files into Confluence wiki markup.
+A simple utility to convert Markdown files into Word documents.
 
 ```bash
-md-to-confluence input.md output.confluence
+md-to-confluence input.md output.docx
 ```

--- a/md_to_confluence/__init__.py
+++ b/md_to_confluence/__init__.py
@@ -3,7 +3,7 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
-"""md_to_confluence package."""
+"""Utilities for converting Markdown files to Word documents."""
 
 __all__ = ["convert"]
 __version__ = "0.1.0"

--- a/md_to_confluence/cli.py
+++ b/md_to_confluence/cli.py
@@ -14,9 +14,9 @@ from .converter import convert
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Convert markdown to Confluence markup")
+    parser = argparse.ArgumentParser(description="Convert Markdown to a Word .docx file")
     parser.add_argument("input", type=Path, help="Markdown file")
-    parser.add_argument("output", type=Path, help="Output file for Confluence text")
+    parser.add_argument("output", type=Path, help="Output .docx file")
 
     args = parser.parse_args(argv)
 

--- a/md_to_confluence/converter.py
+++ b/md_to_confluence/converter.py
@@ -3,7 +3,7 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
-"""Conversion utilities for Markdown to Confluence."""
+"""Conversion utilities for Markdown to Word documents."""
 
 from __future__ import annotations
 
@@ -14,20 +14,20 @@ import pyperclip
 from pyperclip import PyperclipException
 
 
-def convert(input_path: str | Path, output_path: str | Path) -> str:
-    """Convert markdown file to Confluence wiki markup.
+def convert(input_path: str | Path, output_path: str | Path) -> Path:
+    """Convert markdown file to a Word ``.docx`` document.
 
     Parameters
     ----------
     input_path: str | Path
         Path to the Markdown file.
     output_path: str | Path
-        Where to store the generated Confluence markup.
+        Where to store the generated Word document.
 
     Returns
     -------
-    str
-        The generated markup as a string.
+    Path
+        Path to the generated Word document.
     """
 
     input_file = Path(input_path)
@@ -35,14 +35,21 @@ def convert(input_path: str | Path, output_path: str | Path) -> str:
 
     text = input_file.read_text()
 
-    # Convert using pandoc. The 'jira' format matches Confluence wiki markup.
-    confluence_text = pypandoc.convert_text(text, "jira", format="md")
+    # Ensure the pandoc binary is available.
+    pypandoc.ensure_pandoc_installed()
+
+    # Convert using pandoc to retain complex entities such as tables.
+    pypandoc.convert_text(
+        text,
+        "docx",
+        format="md",
+        outputfile=str(output_file),
+    )
 
     try:
-        pyperclip.copy(confluence_text)
+        pyperclip.copy(str(output_file))
     except PyperclipException:
         # Clipboard support is optional. Continue without failing.
         pass
 
-    output_file.write_text(confluence_text)
-    return confluence_text
+    return output_file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ build-backend = "hatchling.build"
 [project]
 name = "md-to-confluence"
 version = "0.1.0"
-description = "Convert Markdown to Confluence wiki markup and copy to clipboard"
+description = "Convert Markdown files to Word (.docx) documents"
 authors = [
     {name = "Cybrota", email = "noreply@example.com"},
 ]
 license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 dependencies = [
-    "pypandoc>=1.7",
+    "pypandoc-binary>=1.7",
     "pyperclip>=1.8",
 ]
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -5,6 +5,7 @@
 # you may not use this file except in compliance with the License.
 
 import pyperclip
+from pathlib import Path
 
 import md_to_confluence.converter as conv
 
@@ -12,13 +13,18 @@ import md_to_confluence.converter as conv
 def test_convert(tmp_path, monkeypatch):
     md_text = "# Title"
     input_file = tmp_path / "test.md"
-    output_file = tmp_path / "out.txt"
+    output_file = tmp_path / "out.docx"
     input_file.write_text(md_text)
 
     monkeypatch.setattr(pyperclip, "copy", lambda text: None)
-    monkeypatch.setattr(conv.pypandoc, "convert_text", lambda *a, **k: "h1. Title")
+
+    def fake_convert_text(*args, **kwargs):
+        Path(kwargs["outputfile"]).write_text("docx")
+        return ""
+
+    monkeypatch.setattr(conv.pypandoc, "convert_text", fake_convert_text)
 
     result = conv.convert(input_file, output_file)
 
-    assert output_file.read_text() == "h1. Title"
-    assert result == "h1. Title"
+    assert output_file.read_text() == "docx"
+    assert result == output_file


### PR DESCRIPTION
## Summary
- convert Markdown files to Word `.docx`
- update CLI to mention `.docx` output
- ensure pandoc binary available via dependency
- adjust README
- update tests for new behaviour

## Testing
- `ruff check .`
- `bandit -r md_to_confluence -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866d66e57f88332b2911eea4a47363d