### PR TITLE
Support Word 2013 doc format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # md-to-confluence
 
 `md-to-confluence` is a command line tool that converts Markdown files into Word
-(`.docx`) documents. The tool relies on Pandoc and provides a simple interface
+(`.doc`) documents. The tool relies on Pandoc and provides a simple interface
 for local documentation workflows.
 
 ## Build requirements

--- a/md_to_confluence/cli.py
+++ b/md_to_confluence/cli.py
@@ -14,9 +14,9 @@ from .converter import convert
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Convert Markdown to a Word .docx file")
+    parser = argparse.ArgumentParser(description="Convert Markdown to a Word .doc file")
     parser.add_argument("input", type=Path, help="Markdown file")
-    parser.add_argument("output", type=Path, help="Output .docx file")
+    parser.add_argument("output", type=Path, help="Output .doc file")
 
     args = parser.parse_args(argv)
 

--- a/md_to_confluence/converter.py
+++ b/md_to_confluence/converter.py
@@ -15,7 +15,7 @@ from pyperclip import PyperclipException
 
 
 def convert(input_path: str | Path, output_path: str | Path) -> Path:
-    """Convert markdown file to a Word ``.docx`` document.
+    """Convert markdown file to a Word ``.doc`` document.
 
     Parameters
     ----------
@@ -41,7 +41,7 @@ def convert(input_path: str | Path, output_path: str | Path) -> Path:
     # Convert using pandoc to retain complex entities such as tables.
     pypandoc.convert_text(
         text,
-        "docx",
+        "doc",
         format="md",
         outputfile=str(output_file),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "md-to-confluence"
 version = "0.1.0"
-description = "Convert Markdown files to Word (.docx) documents"
+description = "Convert Markdown files to Word (.doc) documents"
 authors = [
     {name = "Cybrota", email = "noreply@example.com"},
 ]

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -13,18 +13,18 @@ import md_to_confluence.converter as conv
 def test_convert(tmp_path, monkeypatch):
     md_text = "# Title"
     input_file = tmp_path / "test.md"
-    output_file = tmp_path / "out.docx"
+    output_file = tmp_path / "out.doc"
     input_file.write_text(md_text)
 
     monkeypatch.setattr(pyperclip, "copy", lambda text: None)
 
     def fake_convert_text(*args, **kwargs):
-        Path(kwargs["outputfile"]).write_text("docx")
+        Path(kwargs["outputfile"]).write_text("doc")
         return ""
 
     monkeypatch.setattr(conv.pypandoc, "convert_text", fake_convert_text)
 
     result = conv.convert(input_file, output_file)
 
-    assert output_file.read_text() == "docx"
+    assert output_file.read_text() == "doc"
     assert result == output_file


### PR DESCRIPTION
## Summary
- switch default output format from `.docx` to `.doc`
- update CLI help and README
- adjust tests for `.doc`

## Testing
- `ruff check .`
- `bandit -r md_to_confluence`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6866dadcec4883329fc532064c210bd3