### PR TITLE
Fix CLI to use docx format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # md-to-confluence
 
 `md-to-confluence` is a command line tool that converts Markdown files into Word
-(`.doc`) documents. The tool relies on Pandoc and provides a simple interface
+(`.docx`) documents. The tool relies on Pandoc and provides a simple interface
 for local documentation workflows.
 
 ## Build requirements

--- a/md_to_confluence/cli.py
+++ b/md_to_confluence/cli.py
@@ -14,9 +14,9 @@ from .converter import convert
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Convert Markdown to a Word .doc file")
+    parser = argparse.ArgumentParser(description="Convert Markdown to a Word .docx file")
     parser.add_argument("input", type=Path, help="Markdown file")
-    parser.add_argument("output", type=Path, help="Output .doc file")
+    parser.add_argument("output", type=Path, help="Output .docx file")
 
     args = parser.parse_args(argv)
 

--- a/md_to_confluence/converter.py
+++ b/md_to_confluence/converter.py
@@ -15,7 +15,7 @@ from pyperclip import PyperclipException
 
 
 def convert(input_path: str | Path, output_path: str | Path) -> Path:
-    """Convert markdown file to a Word ``.doc`` document.
+    """Convert markdown file to a Word ``.docx`` document.
 
     Parameters
     ----------
@@ -41,7 +41,7 @@ def convert(input_path: str | Path, output_path: str | Path) -> Path:
     # Convert using pandoc to retain complex entities such as tables.
     pypandoc.convert_text(
         text,
-        "doc",
+        "docx",
         format="md",
         outputfile=str(output_file),
     )


### PR DESCRIPTION
## Summary
- correct CLI/help text and conversion function to output docx
- update documentation to reference docx files

## Testing
- `ruff check .`
- `bandit -r md_to_confluence`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6866df3b6fe88332a84edfda9120f62e