### PR TITLE
feat: ensure docx uses modern Word version

### DIFF
--- a/md_to_confluence/converter.py
+++ b/md_to_confluence/converter.py
@@ -8,10 +8,36 @@
 from __future__ import annotations
 
 from pathlib import Path
+from zipfile import ZipFile
+import re
 
 import pypandoc
 import pyperclip
 from pyperclip import PyperclipException
+
+
+def _set_app_version(docx_file: Path, version: str = "16.0000") -> None:
+    """Update ``docProps/app.xml`` ``AppVersion`` to mimic newer Word versions."""
+
+    with ZipFile(docx_file) as zf:
+        files = {name: zf.read(name) for name in zf.namelist()}
+
+    app_xml = files.get("docProps/app.xml")
+    if not app_xml:
+        return
+
+    text = app_xml.decode("utf-8")
+    new_text, count = re.subn(
+        r"<AppVersion>[^<]*</AppVersion>",
+        f"<AppVersion>{version}</AppVersion>",
+        text,
+        count=1,
+    )
+    if count:
+        files["docProps/app.xml"] = new_text.encode()
+        with ZipFile(docx_file, "w") as zf:
+            for name, data in files.items():
+                zf.writestr(name, data)
 
 
 def convert(input_path: str | Path, output_path: str | Path) -> Path:
@@ -45,6 +71,9 @@ def convert(input_path: str | Path, output_path: str | Path) -> Path:
         format="md",
         outputfile=str(output_file),
     )
+
+    # Ensure the file advertises a modern Word version.
+    _set_app_version(output_file)
 
     try:
         pyperclip.copy(str(output_file))


### PR DESCRIPTION
## Summary
- update converter to set the AppVersion field so docx targets Word 2010+
- test that conversion updates AppVersion to 16.0000

## Testing
- `ruff check .`
- `bandit -r md_to_confluence`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e132fcf08332b5657223cf0ef7e8