### PR TITLE
Add Go-based converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,32 @@
 # md-to-confluence
 
-`md-to-confluence` is a command line tool that converts Markdown files into Word
-(`.docx`) documents. The tool relies on Pandoc and provides a simple interface
-for local documentation workflows.
+`md-to-confluence` provides a command line tool that converts Markdown files
+into Word (`.docx`) documents. The initial implementation used Python and
+Pandoc. A Go based CLI is now available which relies on Pandoc and LibreOffice
+for improved compatibility with Confluence imports.
 
 ## Build requirements
 
-- **Python 3.8 or later**
-- **Hatch** for packaging and building. Install it using `pip install hatch` or
-  `pipx install hatch`.
-
-Runtime dependencies such as `pypandoc-binary` and `pyperclip` are installed
-when you install the package.
+- **Go 1.21 or later**
+- **Python 3.8 or later** (only required for legacy version and tests)
+  Runtime dependencies such as `pypandoc-binary` and `pyperclip` are installed
+  when you install the Python package.
 
 ## Building from source with Hatch
 
-1. Install the build requirements listed above.
-2. From the repository root, run:
+1. Install Go and the other build requirements listed above.
+2. Build the Go CLI using:
    ```bash
-   hatch build
+   go build ./cmd/mdtoconf
    ```
-   This creates distribution archives inside the `dist/` directory.
+   This produces a binary named `mdtoconf`.
+3. The Python package can still be built with Hatch if required.
 
 ## Installing the package
 
-After building, install the generated wheel into your environment:
+After building the Go binary you can install it with `go install` or copy the
+binary into your `PATH`. If building the Python package, install the generated
+wheel into your environment:
 
 ```bash
 pip install dist/md_to_confluence-0.1.0-py3-none-any.whl
@@ -42,7 +44,7 @@ The project uses Ruff for linting, Bandit for security checks and Pytest for
 unit tests. After installing these tools, run:
 
 ```bash
-md-to-confluence input.md output.docx
+mdtoconf -input input.md -output output.docx
 ```
 
 Now, one can import `output.docx` into Confluence by:

--- a/cmd/mdtoconf/main.go
+++ b/cmd/mdtoconf/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/example/md-to-confluence/converter"
+)
+
+func main() {
+	input := flag.String("input", "", "markdown file")
+	output := flag.String("output", "", "output docx file")
+	flag.Parse()
+
+	if *input == "" || *output == "" {
+		flag.Usage()
+		return
+	}
+
+	out, err := converter.Convert(*input, *output)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println(out)
+}

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -1,0 +1,115 @@
+package converter
+
+import (
+	"archive/zip"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+
+	"github.com/atotto/clipboard"
+)
+
+var runPandoc = func(input, output string) error {
+	cmd := exec.Command("pandoc", input, "-o", output)
+	return cmd.Run()
+}
+
+var runLibreOffice = func(input, outDir string) error {
+	cmd := exec.Command("libreoffice", "--headless", "--convert-to", "docx", input, "--outdir", outDir)
+	return cmd.Run()
+}
+
+func setAppVersion(docxFile, version string) error {
+	rd, err := zip.OpenReader(docxFile)
+	if err != nil {
+		return err
+	}
+	defer rd.Close()
+
+	files := make(map[string][]byte)
+	for _, f := range rd.File {
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		data, err := ioutil.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			return err
+		}
+		files[f.Name] = data
+	}
+
+	app := files["docProps/app.xml"]
+	if len(app) > 0 {
+		re := regexp.MustCompile(`<AppVersion>[^<]*</AppVersion>`)
+		repl := []byte("<AppVersion>" + version + "</AppVersion>")
+		newText := re.ReplaceAll(app, repl)
+		files["docProps/app.xml"] = newText
+	}
+
+	tmp := docxFile + ".tmp"
+	wz, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	zw := zip.NewWriter(wz)
+	for name, data := range files {
+		w, err := zw.Create(name)
+		if err != nil {
+			zw.Close()
+			wz.Close()
+			os.Remove(tmp)
+			return err
+		}
+		_, err = w.Write(data)
+		if err != nil {
+			zw.Close()
+			wz.Close()
+			os.Remove(tmp)
+			return err
+		}
+	}
+	zw.Close()
+	wz.Close()
+	err = os.Rename(tmp, docxFile)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func copyToClipboard(path string) {
+	_ = clipboard.WriteAll(path)
+}
+
+func Convert(inputPath, outputPath string) (string, error) {
+	tmpDir, err := os.MkdirTemp("", "md2conf")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	docFile := filepath.Join(tmpDir, "temp.doc")
+	if err := runPandoc(inputPath, docFile); err != nil {
+		return "", err
+	}
+
+	if err := runLibreOffice(docFile, tmpDir); err != nil {
+		return "", err
+	}
+
+	docxFile := filepath.Join(tmpDir, "temp.docx")
+	if err := os.Rename(docxFile, outputPath); err != nil {
+		return "", err
+	}
+
+	if err := setAppVersion(outputPath, "16.0000"); err != nil {
+		return "", err
+	}
+
+	copyToClipboard(outputPath)
+	return outputPath, nil
+}

--- a/converter/converter_test.go
+++ b/converter/converter_test.go
@@ -1,0 +1,62 @@
+package converter
+
+import (
+	"archive/zip"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConvert(t *testing.T) {
+	tmpDir := t.TempDir()
+	inputFile := filepath.Join(tmpDir, "in.md")
+	outputFile := filepath.Join(tmpDir, "out.docx")
+	if err := os.WriteFile(inputFile, []byte("# title"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	runPandoc = func(input, output string) error {
+		return os.WriteFile(output, []byte("doc"), 0644)
+	}
+	runLibreOffice = func(input, outDir string) error {
+		docx := filepath.Join(outDir, "temp.docx")
+		f, err := os.Create(docx)
+		if err != nil {
+			return err
+		}
+		zw := zip.NewWriter(f)
+		w, _ := zw.Create("docProps/app.xml")
+		w.Write([]byte("<AppVersion>12.0000</AppVersion>"))
+		zw.Create("word/document.xml")
+		zw.Close()
+		f.Close()
+		return nil
+	}
+
+	result, err := Convert(inputFile, outputFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := zip.OpenReader(outputFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	var appData []byte
+	for _, f := range r.File {
+		if f.Name == "docProps/app.xml" {
+			rc, _ := f.Open()
+			appData, _ = ioutil.ReadAll(rc)
+			rc.Close()
+		}
+	}
+	if string(appData) != "<AppVersion>16.0000</AppVersion>" {
+		t.Fatalf("unexpected AppVersion: %s", appData)
+	}
+	if result != outputFile {
+		t.Fatalf("expected %s got %s", outputFile, result)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/example/md-to-confluence
+
+go 1.23.8
+
+require github.com/atotto/clipboard v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=


### PR DESCRIPTION
## Summary
- add Go module with converter and CLI
- update README for Go build instructions
- provide Go unit tests

## Testing
- `ruff check md_to_confluence tests`
- `bandit -r md_to_confluence -ll`
- `pytest tests -q`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6866e890d5908332b98736f1e31b732f